### PR TITLE
Fix app position

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 /* global __dirname, process */
 
-const { app, BrowserWindow, Tray, Menu, ipcMain } = require('electron');
+const { app, BrowserWindow, Tray, Menu, ipcMain, screen } = require('electron');
 const path = require('path');
 
 // For hot reload during development (optional)
@@ -72,12 +72,34 @@ function toggleWindow() {
 function showWindow() {
   const trayBounds = tray.getBounds();
   const windowBounds = window.getBounds();
-  const x = Math.round(
-    trayBounds.x + trayBounds.width / 2 - windowBounds.width / 2
-  );
-  const y = Math.round(trayBounds.y + trayBounds.height);
+  const screenBounds = screen.getPrimaryDisplay().workArea;
 
-  window.setPosition(x, y, false);
+  // Calculate center positions, used to determine where to place the app window
+  const trayCenterX = trayBounds.x + trayBounds.width / 2;
+  const trayCenterY = trayBounds.y + trayBounds.height / 2;
+
+  const screenCenterX = screenBounds.x + screenBounds.width / 2;
+  const screenCenterY = screenBounds.y + screenBounds.height / 2;
+
+  const isTop = trayCenterY < screenCenterY;
+  const isLeft = trayCenterX < screenCenterX;
+
+  let x = 0;
+  let y = 0;
+
+  if (isLeft) {
+    x = screenBounds.x;
+  } else {
+    x = screenBounds.x + screenBounds.width - windowBounds.width;
+  }
+
+  if (isTop) {
+    y = screenBounds.y;
+  } else {
+    y = screenBounds.y + screenBounds.height - windowBounds.height;
+  }
+
+  window.setPosition(Math.round(x), Math.round(y), false);
   window.show();
   window.focus();
 }

--- a/main.js
+++ b/main.js
@@ -72,8 +72,7 @@ function toggleWindow() {
 function showWindow() {
   const trayBounds = tray.getBounds();
   const windowBounds = window.getBounds();
-  const screenBounds = screen.getPrimaryDisplay().workArea;
-
+  const screenBounds = screen.getDisplayMatching(trayBounds).workArea;
   // Calculate center positions, used to determine where to place the app window
   const trayCenterX = trayBounds.x + trayBounds.width / 2;
   const trayCenterY = trayBounds.y + trayBounds.height / 2;


### PR DESCRIPTION
Here I am fixing the positioning of the app when it appears on the screen. Before this change, it was expecting the tray to always be in the top left corner of your screeen. This might be true on some OSs, but not on all.

I ran into this issue while trying to run this app on a Windows 11 machine, where my tray was in the standard bottom right corner location. The app was attempting to open the window below the bounds of my screen, effectively never showing the app on my screen, making it unusable.