### PR TITLE
Add new random colors to notes and fix z index when dragging notes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -95,7 +95,7 @@ body {
 
 /* Note card styling */
 .note {
-  min-width: 220px;
+  min-width: 330px;
   min-height: 280px;
   box-sizing: border-box;
   background-color: #fffab3;
@@ -133,11 +133,17 @@ body {
 .note .delete-button {
   position: absolute;
   right: 8px;
+  top: 8px;
   cursor: pointer;
-}
-.note .delete-button img {
+  color: black;
+  font-size: 16px;
+  font-weight: bold;
   width: 16px;
   height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
 }
 .note .note-title {
   width: 100%;
@@ -233,11 +239,6 @@ body {
   border: none;
 }
 
-/* Pinned notes get a red border */
-.note.pinned-note {
-  border: 2px solid red;
-}
-
 /* Utility class to hide elements */
 .hidden {
   display: none !important;
@@ -272,8 +273,8 @@ body {
 /* Fixed button styles */
 #new-note {
   position: fixed;
-  bottom: 20px;
-  right: 80px;
+  bottom: 80px;
+  right: 20px;
   width: 50px;
   height: 50px;
   background-color: rgba(255, 255, 0, 0.5);
@@ -288,13 +289,21 @@ body {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background-color: transparent;
+  width: 50px;
+  height: 50px;
+  background-color: rgba(255, 255, 255, 0.8);
   border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 #menu-button img {
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
 }
 
 /* Side menu styling */

--- a/styles.scss
+++ b/styles.scss
@@ -111,7 +111,7 @@ body {
 
 /* Note card styling */
 .note {
-  min-width: 220px;
+  min-width: 330px;
   min-height: 280px;
   box-sizing: border-box;
   background-color: #fffab3;
@@ -153,12 +153,17 @@ body {
   .delete-button {
     position: absolute;
     right: 8px;
+    top: 8px;
     cursor: pointer;
-
-    img {
-      width: 16px;
-      height: 16px;
-    }
+    color: black;
+    font-size: 16px;
+    font-weight: bold;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
   }
 
   .note-title {
@@ -270,10 +275,6 @@ body {
   }
 }
 
-/* Pinned notes get a red border */
-.note.pinned-note {
-  border: 2px solid red;
-}
 
 /* Utility class to hide elements */
 .hidden {
@@ -310,8 +311,8 @@ body {
 /* Fixed button styles */
 #new-note {
   position: fixed;
-  bottom: 20px;
-  right: 80px;
+  bottom: 80px;
+  right: 20px;
   width: 50px;
   height: 50px;
   background-color: $new-note-bg;
@@ -326,13 +327,21 @@ body {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background-color: transparent;
+  width: 50px;
+  height: 50px;
+  background-color: rgba(255, 255, 255, 0.8);
   border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   img {
-    width: 40px;
-    height: 40px;
+    width: 30px;
+    height: 30px;
   }
 }
 


### PR DESCRIPTION
Adding a random color allocation to new notes. Also fixing a bug around dragging of the notes. The dragged notes can now be above the note it was dragged on top of. also clicking on note will bring it forward into the ofcus

<img width="798" alt="image" src="https://github.com/user-attachments/assets/b15f038b-dedb-43d3-900e-0b1070ffcf4a" />
